### PR TITLE
8. Темизация: переключатель тем и сохранение выбора

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -4,6 +4,21 @@
   flex-direction: column;
 }
 
+.app-header {
+  display: flex;
+  justify-content: flex-end;
+  padding: 12px 16px;
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.theme-toggle {
+  font-size: 18px;
+  padding: 8px 12px;
+  line-height: 1;
+}
+
 .page-setup,
 .page-training {
   flex-grow: 1;

--- a/src/index.css
+++ b/src/index.css
@@ -24,14 +24,24 @@
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
 
-  @media (max-width: 1024px) {
-    font-size: 16px;
-  }
+[data-theme='dark'] {
+  --text: #9ca3af;
+  --text-h: #f3f4f6;
+  --bg: #16171d;
+  --border: #2e303a;
+  --code-bg: #1f2028;
+  --accent: #c084fc;
+  --accent-bg: rgba(192, 132, 252, 0.15);
+  --accent-border: rgba(192, 132, 252, 0.5);
+  --social-bg: rgba(47, 48, 58, 0.5);
+  --shadow:
+    rgba(0, 0, 0, 0.4) 0 10px 15px -3px, rgba(0, 0, 0, 0.25) 0 4px 6px -2px;
 }
 
 @media (prefers-color-scheme: dark) {
-  :root {
+  :root:not([data-theme]) {
     --text: #9ca3af;
     --text-h: #f3f4f6;
     --bg: #16171d;
@@ -43,10 +53,6 @@
     --social-bg: rgba(47, 48, 58, 0.5);
     --shadow:
       rgba(0, 0, 0, 0.4) 0 10px 15px -3px, rgba(0, 0, 0, 0.25) 0 4px 6px -2px;
-  }
-
-  #social .button-icon {
-    filter: invert(1) brightness(2);
   }
 }
 
@@ -77,19 +83,12 @@ h1 {
   font-size: 56px;
   letter-spacing: -1.68px;
   margin: 32px 0;
-  @media (max-width: 1024px) {
-    font-size: 36px;
-    margin: 20px 0;
-  }
 }
 h2 {
   font-size: 24px;
   line-height: 118%;
   letter-spacing: -0.24px;
   margin: 0 0 8px;
-  @media (max-width: 1024px) {
-    font-size: 20px;
-  }
 }
 p {
   margin: 0;
@@ -108,4 +107,17 @@ code {
   line-height: 135%;
   padding: 4px 8px;
   background: var(--code-bg);
+}
+
+@media (max-width: 1024px) {
+  :root {
+    font-size: 16px;
+  }
+  h1 {
+    font-size: 36px;
+    margin: 20px 0;
+  }
+  h2 {
+    font-size: 20px;
+  }
 }

--- a/src/shared/ThemeStore.ts
+++ b/src/shared/ThemeStore.ts
@@ -1,0 +1,39 @@
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+
+export type Theme = 'light' | 'dark'
+
+interface ThemeState {
+  theme: Theme
+  toggleTheme: () => void
+  setTheme: (theme: Theme) => void
+}
+
+export const useThemeStore = create<ThemeState>()(
+  persist(
+    (set) => ({
+      theme: 'light',
+
+      toggleTheme: () =>
+        set((state) => ({ theme: state.theme === 'light' ? 'dark' : 'light' })),
+
+      setTheme: (theme) => set({ theme }),
+    }),
+    {
+      name: 'langley-theme',
+    },
+  ),
+)
+
+// Apply saved theme before React paints (prevents flash of wrong theme)
+const saved = localStorage.getItem('langley-theme')
+if (saved) {
+  try {
+    const { state } = JSON.parse(saved)
+    if (state?.theme) {
+      document.documentElement.dataset.theme = state.theme
+    }
+  } catch {
+    // ignore malformed JSON
+  }
+}

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -1,1 +1,2 @@
-export {}
+export { useThemeStore } from './ThemeStore'
+export type { Theme } from './ThemeStore'

--- a/src/ui/Layout.tsx
+++ b/src/ui/Layout.tsx
@@ -1,8 +1,27 @@
+import { useEffect } from 'react'
 import { Outlet } from 'react-router-dom'
+import { useThemeStore } from '../shared/ThemeStore'
 
 export function Layout() {
+  const { theme, toggleTheme } = useThemeStore()
+
+  // Sync theme attribute to <html> whenever it changes
+  useEffect(() => {
+    document.documentElement.dataset.theme = theme
+  }, [theme])
+
   return (
     <div className="app-layout">
+      <header className="app-header">
+        <button
+          className="theme-toggle btn-secondary"
+          onClick={toggleTheme}
+          title={theme === 'light' ? 'Включить тёмную тему' : 'Включить светлую тему'}
+          aria-label={theme === 'light' ? 'Включить тёмную тему' : 'Включить светлую тему'}
+        >
+          {theme === 'light' ? '🌙' : '☀️'}
+        </button>
+      </header>
       <Outlet />
     </div>
   )


### PR DESCRIPTION
## Что сделано

### ThemeStore (src/shared/ThemeStore.ts)
- Zustand + persist middleware → localStorage key: `langley-theme`
- `theme: 'light' | 'dark'`, `toggleTheme()`, `setTheme()`

### CSS (src/index.css)
- Заменён `@media (prefers-color-scheme: dark)` на `[data-theme='dark']` селектор
- `:root:not([data-theme])` для system preference fallback
- Медиа-запросы font-size вынесены отдельно

### Layout (src/ui/Layout.tsx)
- Кнопка-переключатель в header: 🌙 для тёмной, ☀️ для светлой
- `useEffect` синхронизирует `data-theme` на `<html>` при каждом изменении

### Flash prevention
- Theme читается из localStorage синхронно при загрузке модуля
- `data-theme` ставится до первого paint

Closes #15